### PR TITLE
feat: allow token query and cookie auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,9 @@ ORIGIN=https://your-site.netlify.app  # Frontend URL
 SHARED_TOKEN=secret123            # Optional auth token
 ```
 
+Clients can send the shared token using the `Authorization` header, a `token` query
+parameter, or a `token` cookie.
+
 ### Frontend Environment Variables
 ```env
 VITE_MEDIA_BASE_URL=https://watch.example.com

--- a/server/README.md
+++ b/server/README.md
@@ -124,10 +124,21 @@ Health check endpoint.
 ### GET /api/videos
 List all available videos.
 
-**Headers** (if `SHARED_TOKEN` is set):
+**Authentication** (if `SHARED_TOKEN` is set):
+
+Provide the token using one of the following:
+
 ```
 Authorization: Bearer YOUR_TOKEN
 ```
+
+Or as a query parameter:
+
+```
+?token=YOUR_TOKEN
+```
+
+Or via a cookie named `token`.
 
 **Response:**
 ```json
@@ -145,9 +156,12 @@ Authorization: Bearer YOUR_TOKEN
 ### GET /media/:path
 Stream video/caption files with Range support.
 
-**Headers** (if `SHARED_TOKEN` is set):
+**Authentication** (if `SHARED_TOKEN` is set):
+
+Token may be supplied in the `Authorization` header, a `token` query parameter, or a `token` cookie.
+
+**Headers**:
 ```
-Authorization: Bearer YOUR_TOKEN
 Range: bytes=0-1023
 ```
 


### PR DESCRIPTION
## Summary
- allow auth tokens in Authorization header, `token` query param or `token` cookie
- document token usage for `/api/videos` and `/media` endpoints

## Testing
- `./test.sh`
- `curl -i http://localhost:8080/api/videos` *(fails without token)*
- `curl -i 'http://localhost:8080/api/videos?token=secret'`
- `curl -i --cookie 'token=secret' http://localhost:8080/api/videos`


------
https://chatgpt.com/codex/tasks/task_e_68b315c81bc0832593b499d9f7e554e4

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - API authentication is more flexible: the shared token can be provided via Authorization header (Bearer), a token query parameter, or a token cookie. Returns clearer 401 errors for invalid or missing tokens. No changes to response formats.
- Documentation
  - Updated guides to reflect multiple authentication methods with examples for video listing and media endpoints, and clarified header usage (including Range).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->