### PR TITLE
Persist and sync room video state

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -182,6 +182,7 @@ const wss = new WebSocketServer({
 
 // Room management
 const rooms = new Map() // roomId -> Set of client websockets
+const roomStates = new Map() // roomId -> { videoUrl, currentTime, paused }
 
 wss.on('connection', (ws, req) => {
   const url = new URL(req.url, `http://${req.headers.host}`)
@@ -214,6 +215,21 @@ wss.on('connection', (ws, req) => {
 
   console.log(`Client ${clientId} joined room ${roomId}. Room size: ${room.size}`)
 
+  // Send current room state to new client
+  const existingState = roomStates.get(roomId)
+  if (existingState && existingState.videoUrl) {
+    const baseMessage = {
+      roomId,
+      clientId: 'server',
+      currentTime: existingState.currentTime,
+      paused: existingState.paused,
+      sentAtMs: Date.now(),
+      videoUrl: existingState.videoUrl
+    }
+    ws.send(JSON.stringify({ ...baseMessage, type: 'loadVideo' }))
+    ws.send(JSON.stringify({ ...baseMessage, type: 'timeSync' }))
+  }
+
   ws.on('message', (data) => {
     try {
       const message = JSON.parse(data.toString())
@@ -223,12 +239,24 @@ wss.on('connection', (ws, req) => {
         return
       }
 
+      // Update room state for sync messages
+      if (['loadVideo', 'play', 'pause', 'seek', 'timeSync'].includes(message.type)) {
+        const currentState = roomStates.get(message.roomId) || { currentTime: 0, paused: true }
+        if (message.videoUrl) {
+          currentState.videoUrl = message.videoUrl
+        }
+        currentState.currentTime = message.currentTime
+        currentState.paused = message.paused
+        roomStates.set(message.roomId, currentState)
+      }
+
       // Broadcast to all other clients in the same room
       const room = rooms.get(message.roomId)
       if (room) {
+        const payload = JSON.stringify(message)
         room.forEach(client => {
           if (client !== ws && client.readyState === client.OPEN) {
-            client.send(data)
+            client.send(payload)
           }
         })
       }
@@ -242,10 +270,11 @@ wss.on('connection', (ws, req) => {
     if (room) {
       room.delete(ws)
       console.log(`Client ${clientId} left room ${roomId}. Room size: ${room.size}`)
-      
+
       // Clean up empty rooms
       if (room.size === 0) {
         rooms.delete(roomId)
+        roomStates.delete(roomId)
         console.log(`Room ${roomId} deleted (empty)`)
       }
     }

--- a/web/src/ws.ts
+++ b/web/src/ws.ts
@@ -21,9 +21,12 @@ export class WSClient {
           resolve()
         }
 
-        this.ws.onmessage = (event) => {
+        this.ws.onmessage = async (event) => {
           try {
-            const message: WSMessage = JSON.parse(event.data)
+            const raw = typeof event.data === 'string'
+              ? event.data
+              : await (event.data as Blob).text()
+            const message: WSMessage = JSON.parse(raw)
             this.messageHandlers.forEach(handler => handler(message))
           } catch (err) {
             console.error('Failed to parse WebSocket message:', err)


### PR DESCRIPTION
## Summary
- Track per-room video status on the server and send to new connections
- Load remote videos on clients when receiving sync messages
- Ensure WebSocket messages use JSON strings and parse Blob payloads on the client

## Testing
- `cd server && npm test` *(fails: Missing script "test")*
- `cd ../web && npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_68b3417f11f08325aba00ae8117b30ac