### PR TITLE
feat: add AirPlay support to video player

### DIFF
--- a/web/src/components/VideoPlayer.tsx
+++ b/web/src/components/VideoPlayer.tsx
@@ -5,6 +5,14 @@ import { calculateDriftAdjustedTime, shouldSeekToTime, createSyncMessage } from 
 import { getVideoStreamUrl } from '../api'
 import { WSMessage, VideoInfo } from '../types'
 
+interface AirPlayVideoElement extends HTMLVideoElement {
+  webkitShowPlaybackTargetPicker?: () => void
+}
+
+interface WebKitPlaybackTargetAvailabilityEvent extends Event {
+  availability: string
+}
+
 // Utility function to detect iOS devices
 const isIOS = () => {
   return /iPad|iPhone|iPod/.test(navigator.userAgent) || 
@@ -21,6 +29,7 @@ function VideoPlayer() {
   const [lastSyncTime, setLastSyncTime] = useState(0)
   const [audioBlocked, setAudioBlocked] = useState(false)
   const [isLoading, setIsLoading] = useState(false)
+  const [isAirPlayAvailable, setIsAirPlayAvailable] = useState(false)
   
   const {
     selectedVideo,
@@ -60,6 +69,23 @@ function VideoPlayer() {
     return () => {
       video.removeEventListener('webkitbeginfullscreen', handleWebkitFullscreenChange)
       video.removeEventListener('webkitendfullscreen', handleWebkitFullscreenChange)
+    }
+  }, [selectedVideo])
+
+  // Detect AirPlay availability
+  useEffect(() => {
+    const video = videoRef.current as AirPlayVideoElement | null
+    if (!video || typeof video.addEventListener !== 'function') return
+
+    const handleAirPlayAvailability = (event: Event) => {
+      const availability = (event as WebKitPlaybackTargetAvailabilityEvent).availability
+      setIsAirPlayAvailable(availability === 'available')
+    }
+
+    video.addEventListener('webkitplaybacktargetavailabilitychanged', handleAirPlayAvailability)
+
+    return () => {
+      video.removeEventListener('webkitplaybacktargetavailabilitychanged', handleAirPlayAvailability)
     }
   }, [selectedVideo])
 
@@ -384,6 +410,13 @@ function VideoPlayer() {
     }
   }
 
+  const startAirPlay = () => {
+    const video = videoRef.current as AirPlayVideoElement | null
+    if (video?.webkitShowPlaybackTargetPicker) {
+      video.webkitShowPlaybackTargetPicker()
+    }
+  }
+
   const toggleTheatreMode = () => {
     updatePersonalSettings({ theatreMode: !personalSettings.theatreMode })
   }
@@ -550,7 +583,7 @@ function VideoPlayer() {
                     CC
                   </button>
                 )}
-                
+
                 <button
                   className={`control-button ${personalSettings.theatreMode ? 'active' : ''}`}
                   onClick={toggleTheatreMode}
@@ -558,6 +591,16 @@ function VideoPlayer() {
                 >
                   🎭
                 </button>
+
+                {isAirPlayAvailable && (
+                  <button
+                    className="control-button"
+                    onClick={startAirPlay}
+                    title="AirPlay"
+                  >
+                    📺
+                  </button>
+                )}
 
                 <button
                   className="control-button"


### PR DESCRIPTION
## Summary
- detect availability of AirPlay receivers and expose state
- add control button to launch AirPlay device picker
- type custom AirPlay availability events to satisfy TypeScript

## Testing
- `npm --prefix web run build`
- `npm --prefix web run lint` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_68b3bf3d901c8325912e92469999d0e0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added AirPlay support to the video player for streaming to compatible devices.
  * Automatically detects when AirPlay is available and surfaces a dedicated AirPlay button.
  * Tapping the AirPlay button opens the device picker to start streaming.
  * Existing playback and UI remain unchanged aside from the new AirPlay option.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->